### PR TITLE
replace hard-coded GAE app ID in inbound email addresses

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -25,7 +25,7 @@ class AdminHandler(InboundMailHandler):
     def is_admin(cls, sender):
         """Return True if sender is an admin, otherwise return False."""
         name, mail = email.Utils.parseaddr(sender)
-        return mail in _ADMINS
+        return mail.lower() in (email.lower() for email in _ADMINS)
 
     @classmethod
     def get_subscriptions(cls, body):

--- a/admin.py
+++ b/admin.py
@@ -6,6 +6,7 @@ import webapp2
 
 from google.appengine.api import mail
 from google.appengine.ext.webapp.mail_handlers import InboundMailHandler
+from google.appengine.api import app_identity
 
 import model
 
@@ -53,7 +54,8 @@ class AdminHandler(InboundMailHandler):
     @classmethod
     def get_subscription_msg(cls, to, report):
         """Returns EmailMessage for supplied recipient and report."""
-        reply_to = 'PIF <noreply@piffer-updates.appspotmail.com>'
+        app_id = app_identity.get_application_id()
+        reply_to = 'PIF <noreply@%s.appspotmail.com>' % app_id
         fields = dict(
             sender=reply_to,
             to=to,

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,5 @@
+appname: PIF
+admins:
+  - daniel.hammer@gsa.gov
+  - dan.s.hammer@gmail.com
+  - michelle.m.hood@gmail.com

--- a/cron.py
+++ b/cron.py
@@ -7,6 +7,7 @@ import datetime
 import functools
 import logging
 import webapp2
+import yaml
 
 from google.appengine.api import mail
 from google.appengine.api import app_identity
@@ -16,11 +17,16 @@ import model
 
 class CronUpdateHandler(webapp2.RequestHandler):
 
+    with open('config.yaml', 'r') as f:
+        doc = yaml.load(f);
+    
+    appname = doc["appname"]
+
     @classmethod
     def get_reply_address(cls, urlsafe):
         """Return update email reply address given supplied urlsafe string."""
         app_id = app_identity.get_application_id()
-        return 'PIF <update+%s@%s.appspotmail.com>' % (urlsafe, app_id)
+        return '%s <update+%s@%s.appspotmail.com>' % (cls.appname, urlsafe, app_id)
 
     @classmethod
     def get_update_message(cls, team, to, sender, date):
@@ -35,7 +41,7 @@ class CronUpdateHandler(webapp2.RequestHandler):
             sender=sender,
             to=to,
             reply_to=sender,
-            subject='[PIF-update] Send %s updates - %s' % (team.upper(), day),
+            subject='[%s] Send %s updates - %s' % (cls.appname, team.upper(), day),
             body=header)
         return mail.EmailMessage(**fields)
 
@@ -71,12 +77,12 @@ class CronDigestHandler(webapp2.RequestHandler):
         """Sends update reminder email to subscriber."""
         day = "{:%b %d, %Y}".format(date)
         app_id = app_identity.get_application_id()
-        reply_to = 'PIF <noreply@%s.appspotmail.com>' % app_id
+        reply_to = '%s <noreply@%s.appspotmail.com>' % (cls.appname, app_id)
         fields = dict(
             sender=reply_to,
             to=to,
             reply_to=reply_to,
-            subject='[PIF-update] %s team updates - %s' % (team.upper(), day),
+            subject='[%s] %s team updates - %s' % (cls.appname, team.upper(), day),
             body=digest)
         return mail.EmailMessage(**fields)
 

--- a/cron.py
+++ b/cron.py
@@ -9,6 +9,7 @@ import logging
 import webapp2
 
 from google.appengine.api import mail
+from google.appengine.api import app_identity
 
 import model
 
@@ -18,7 +19,8 @@ class CronUpdateHandler(webapp2.RequestHandler):
     @classmethod
     def get_reply_address(cls, urlsafe):
         """Return update email reply address given supplied urlsafe string."""
-        return 'PIF <update+%s@piffer-updates.appspotmail.com>' % urlsafe
+        app_id = app_identity.get_application_id()
+        return 'PIF <update+%s@%s.appspotmail.com>' % (urlsafe, app_id)
 
     @classmethod
     def get_update_message(cls, team, to, sender, date):
@@ -68,7 +70,8 @@ class CronDigestHandler(webapp2.RequestHandler):
     def get_digest_message(cls, team, digest, date, to):
         """Sends update reminder email to subscriber."""
         day = "{:%b %d, %Y}".format(date)
-        reply_to = 'PIF <noreply@piffer-updates.appspotmail.com>'
+        app_id = app_identity.get_application_id()
+        reply_to = 'PIF <noreply@%s.appspotmail.com>' % app_id
         fields = dict(
             sender=reply_to,
             to=to,

--- a/cron.py
+++ b/cron.py
@@ -72,6 +72,11 @@ class CronUpdateHandler(webapp2.RequestHandler):
 
 class CronDigestHandler(webapp2.RequestHandler):
 
+    with open('config.yaml', 'r') as f:
+        doc = yaml.load(f);
+    
+    appname = doc["appname"]
+
     @classmethod
     def get_digest_message(cls, team, digest, date, to):
         """Sends update reminder email to subscriber."""

--- a/update.py
+++ b/update.py
@@ -2,6 +2,7 @@
 
 import logging
 import webapp2
+import yaml
 from datetime import datetime
 
 from google.appengine.ext import ndb

--- a/update.py
+++ b/update.py
@@ -14,6 +14,11 @@ from model import SubscriberUpdate
 class UpdateHandler(InboundMailHandler):
     """Handler for incoming update emails from subscribers."""
 
+    with open('config.yaml', 'r') as f:
+        doc = yaml.load(f);
+    
+    appname = doc["appname"]
+
     @classmethod
     def get_update(cls, body):
         """Process body to update lines starting with *, return as string."""
@@ -31,9 +36,11 @@ class UpdateHandler(InboundMailHandler):
             '[done]',
             '[Done]',
             '-----Original Message-----',
+            '________________________________________',
+            'From: %s' % cls.appname,
             'Sent from my iPhone',
-            'On Mon, {0:%b} {0.day}, {0:%Y} at 10:00 AM, PIF'.format(dt),
-            'On Mon, {0:%b} {0.day}, {0:%Y}, at 10:00 AM, PIF'.format(dt),
+            'On Mon, {0:%b} {0.day}, {0:%Y} at 10:00 AM, '.format(dt),
+            'On Mon, {0:%b} {0.day}, {0:%Y}, at 10:00 AM, '.format(dt),
             'On {0:%b} {0.day}, {0:%Y} 10:00 AM'.format(dt),
             'On {0:%b} {0.day}, {0:%Y}, at 10:00 AM'.format(dt),
             'Just reply with a few brief bullets starting with'


### PR DESCRIPTION
1. Look up the current GAE app ID and use in all inbound email addresses.
2. Add case-insensitive email address checking when verifying "from" email addresses of inbound admin emails.
3. Move app config into external YAML file & add additional potential strings to match on for email breaks.
